### PR TITLE
Update CHEATS.md to modify initial password

### DIFF
--- a/CHEATS.md
+++ b/CHEATS.md
@@ -12,7 +12,7 @@ If you are unable to find any links without messing up elements/digits, you can 
 Replace `DURATION` with your desired length in the format `MINUTES:SECONDS`: `[site:youtube.com "0:00 / DURATION"]`
 
 ## Initial Password
-The password I use before all the random requirements begin is `94417Vv!octoberXXXVshell`
+The password I use before all the random requirements begin is `94417!octoberXXXVshell`
 
 ## Wordle bypass
 Probably the easiest one of them all.


### PR DESCRIPTION
The password `94417!VvoctoberXXXVshell` doesn't work as the first V will invalidate rule 9 (the roman numeral rule). This is fixed with `94417!octoberXXXVshell`
![Rule 9 is incorrect](https://github.com/pog5/nealpasswordgame/assets/73075315/a0c2f303-75af-4180-b39b-76ed935f0374) | ![Rule 9 is now correct](https://github.com/pog5/nealpasswordgame/assets/73075315/eab87999-3637-41c3-a3bc-7d9d43b47e6e)
-----|-----
Before fix|After fix

